### PR TITLE
Fix crashes, hangs, and stale tests

### DIFF
--- a/src/Configuration.py
+++ b/src/Configuration.py
@@ -8,7 +8,9 @@ from src.Parsers.TheRARBGParser import TheRARBGParser, THE_RARBG_PARSER_NAME
 from src.Show import Show
 from os.path import exists
 from src.utils import ask_for_num, print_colored_list
+from copy import deepcopy
 import os
+import sys
 
 
 CURRENT_CONFIG_VER = 3
@@ -55,6 +57,13 @@ SAMPLE_CONFIG_LINUX = {
     SCRIPT_LINE: [1, 'xdg-open', ''],
 }
 
+SAMPLE_CONFIG_MAC = {
+    CONFIG_VER: CURRENT_CONFIG_VER,
+    DOWNLOAD_DIR: 'dir',
+    SHOW_LIST: [],
+    SCRIPT_LINE: [1, 'open', ''],
+}
+
 class ConfigUpdater:
     def __init__(self, full_json) -> None:
         self.full_json = full_json
@@ -67,6 +76,11 @@ class ConfigUpdater:
         }
 
         while from_v != CURRENT_CONFIG_VER:
+            if from_v not in update_map:
+                print(colored(f"Error: config version {from_v} is not supported (this app supports up to {CURRENT_CONFIG_VER})", 'red'))
+                print(colored("Your config might have been created by a newer version of the app", 'red'))
+                exit(1)
+
             from_v = update_map[from_v]()
 
         print(colored(f"Updated config version to {from_v}", 'green'))
@@ -99,7 +113,11 @@ class ConfigUpdater:
 
             num = ask_for_num('What episode is the last one you have downloaded?',  len(episodes))
 
-            i.update({'last_episode': episodes[num-1][0]})
+            last_episode = None
+            if num != len(episodes):
+                last_episode = episodes[num-1][0]
+
+            i.update({'last_episode': last_episode})
 
     def update_from_1_to_2(self):
         backup_file = 'sys_torrent_backup_V2.cfg'
@@ -133,7 +151,7 @@ class ConfigUpdater:
         return 2
 
     def update_from_2_to_3(self):
-        backup_file = 'sys_torrent_backup_V2.cfg'
+        backup_file = 'sys_torrent_backup_V3.cfg'
 
         with open(backup_file, 'w') as file:
             json.dump(self.full_json, file)
@@ -151,7 +169,8 @@ class Configuration:
             full_json = ConfigUpdater(full_json).update(config_ver)
 
         self.config_json = full_json
-        self.show_list = [Show.from_json(i) for i in self.config_json[SHOW_LIST] if i != None]
+        parsed_shows = (Show.from_json(i) for i in self.config_json[SHOW_LIST] if i is not None)
+        self.show_list = [show for show in parsed_shows if show is not None]
 
     def __getitem__(self, arg):
         return self.config_json[arg]
@@ -175,7 +194,11 @@ class Configuration:
         self.show_list.append(show)
 
     def remove_show(self, show: Show):
-        self.config_json[SHOW_LIST].remove(show.to_json())
+        for idx in range(len(self.config_json[SHOW_LIST])):
+            if Show.from_json(self.config_json[SHOW_LIST][idx]) == show:
+                del self.config_json[SHOW_LIST][idx]
+                break
+
         self.show_list.remove(show)
 
     def update_show(self, show: Show):
@@ -198,9 +221,11 @@ class Configuration:
     @staticmethod
     def get_sample_config():
         if os.name == 'posix':
-             return SAMPLE_CONFIG_LINUX
+            if sys.platform == 'darwin':
+                return deepcopy(SAMPLE_CONFIG_MAC)
+            return deepcopy(SAMPLE_CONFIG_LINUX)
         if os.name == 'nt':
-            return SAMPLE_CONFIG_WINDOWS
+            return deepcopy(SAMPLE_CONFIG_WINDOWS)
 
         print("you appear to be using some weird OS i don't have a config for it so you are gonna have to make it yourself")
         exit(1)

--- a/src/Parsers/EZTVParser.py
+++ b/src/Parsers/EZTVParser.py
@@ -1,9 +1,6 @@
-import asyncio
-
 from termcolor import colored
 from src.Parsers.ParserBase import ParserBase
 import re
-from functools import reduce
 from src.Show import Show
 
 from src.utils import ask_for_num, print_colored_list, ask_for_input
@@ -85,13 +82,18 @@ class EZTVParser(ParserBase):
         all_episodes = []
 
         for i in re.findall(pattern_row, page.text):
-            if stop_after == i[1] and stop_after is not None:
+            magnets = re.findall(pattern_magnet, i)
+            epinfos = re.findall(pattern_epinfo, i)
+
+            if len(magnets) == 0 or len(epinfos) == 0:
+                continue
+
+            epinfo = epinfos[0]
+
+            if stop_after is not None and stop_after == epinfo[1]:
                 break
 
-            magnet = re.findall(pattern_magnet, i)[0]
-            epinfo = re.findall(pattern_epinfo, i)[0]
-
-            all_episodes.append((epinfo[1], epinfo[0], epinfo[2], magnet))
+            all_episodes.append((epinfo[1], epinfo[0], epinfo[2], magnets[0]))
 
         return all_episodes
 

--- a/src/Parsers/NonMagicParserBase.py
+++ b/src/Parsers/NonMagicParserBase.py
@@ -156,8 +156,10 @@ class NonMagicParserBase(ParserBase):
 
             print_colored_list(filtered_episodes, mapper=lambda a: a[0], reverse=True)
 
-            num = ask_for_num('What episode is the last one you have downloaded?',  len(episodes))
-            last_episode = filtered_episodes[num-1][0]
+            num = ask_for_num('What episode is the last one you have downloaded?',  len(filtered_episodes))
+
+            if num != len(filtered_episodes):
+                last_episode = filtered_episodes[num-1][0]
 
         return ep_filter, last_episode
 

--- a/src/Parsers/ParserBase.py
+++ b/src/Parsers/ParserBase.py
@@ -22,7 +22,7 @@ class ParserBase:
         '''
         raise NotImplementedError
 
-    def get_all_show_episodes(self, show, limitб, stop_after=None):
+    def get_all_show_episodes(self, show, limit, stop_after=None):
         '''
         return a list of all episodes that satisfy user query as a list[(episode_title, ... ), ...]
         the length of the list shouldn't exceed limit unless it's set to None
@@ -41,8 +41,14 @@ class ParserBase:
             if show.last_episode is not None and show.last_episode == episode[0]:
                 return new_last
 
+            magnet = self.get_magnet(episode)
+
+            if magnet is None:
+                print(colored(f'''Couldn't get magnet link for "{episode[0].strip()}", skipping it''', 'red'))
+                continue
+
             print(f'Missing "{episode[0].strip()}"')
-            to_download.append(self.get_magnet(episode))
+            to_download.append(magnet)
 
         return new_last
 
@@ -75,7 +81,7 @@ class ParserBase:
             session.headers.update({
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
             })
-            resp = session.get(url, )
+            resp = session.get(url, timeout=30)
 
             if resp.status_code != 200:
                 print(colored(f"Couldn't load '{url}", 'red'))

--- a/src/Search.py
+++ b/src/Search.py
@@ -75,16 +75,16 @@ class SearchEngine:
         print(f'Look up time {time.time() - tm:.3f} sec')
 
         print(colored(f'Found "{best_match[0]}" on {best_match_parser}', 'green'))
-        confindence = max(1 - (min_dist / len(best_match[0])), 0)
-        if confindence < 0.7:
-            print(colored(f'\nWARNING: low confidence score: {confindence*100:0.1f}%', 'yellow'))
+        confidence = max(1 - (min_dist / max(len(best_match[0]), 1)), 0)
+        if confidence < 0.7:
+            print(colored(f'\nWARNING: low confidence score: {confidence*100:0.1f}%', 'yellow'))
             print('\nDo you still want to add it? [y/n]')
             ans = ask_for_input('n (No)')
-            
+
             if len(ans) == 0 or ans[0].lower() == 'n':
                 return None
         else:
-            print(colored(f'Confidence score: {confindence*100:0.1f}%', 'green'))
+            print(colored(f'Confidence score: {confidence*100:0.1f}%', 'green'))
         print()
 
         parser = PARSER_DICT[best_match_parser]()
@@ -114,6 +114,9 @@ class SearchEngine:
         print_colored_list(episodes, mapper=lambda a: a[0], reverse=True)
 
         num = ask_for_num('What episode is the last one you have downloaded?',  len(episodes))
+
+        if num == len(episodes): # the appended 'None of these' entry
+            return None
 
         return episodes[num-1][0]
 

--- a/src/ShowManager.py
+++ b/src/ShowManager.py
@@ -1,5 +1,6 @@
 from threading import Thread
 from copy import deepcopy
+from termcolor import colored
 from src.Configuration import DOWNLOAD_DIR, Configuration, PARSER_DICT
 import time
 
@@ -10,7 +11,13 @@ class ShowManager:
     def check_one(self, show, res):
         print(f'checking "{show.title}"')
         to_download = []
-        last_episode = PARSER_DICT[show.parser_name]().check_show(show, to_download)
+
+        try:
+            last_episode = PARSER_DICT[show.parser_name]().check_show(show, to_download)
+        except Exception as e:
+            print(colored(f'Failed to check "{show.title}": {e}', 'red'))
+            res[0] = []
+            return
 
         new_episodes = len(to_download)
 
@@ -56,14 +63,10 @@ class ShowManager:
 
         for i in range(len(new_config.show_list)):
             threads[i].join()
-            to_download.extend(updates[i][0])
+            if updates[i][0] is not None:
+                to_download.extend(updates[i][0])
             new_config.update_show(new_config.show_list[i])
 
         print(f"Total found: {len(to_download)}")
 
         return to_download, new_config
-
-    @staticmethod
-    def find_show(title: str):
-        for i in PARSER_DICT.values():
-            i.get_all_show_titles()

--- a/src/TorrentUtils.py
+++ b/src/TorrentUtils.py
@@ -8,17 +8,17 @@ class TorrentEngine:
     def __init__(self, script_line) -> None:
         self.script_line = script_line[1:]
         self.magnet_location = script_line[0]
-        self.dowonload_list = []
+        self.download_list = []
 
 
     def add_download(self, magnet: str):
-        self.dowonload_list.append(magnet)
+        self.download_list.append(magnet)
 
     def download(self):
-        for magnet in self.dowonload_list:
+        for magnet in self.download_list:
             if sys.platform == "win32":
                 os.startfile(magnet)
-            elif sys.platform == "linux":
+            else:
                 ls = self.script_line[:]
                 ls[self.magnet_location] = magnet
                 subprocess.Popen(ls).wait()

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,37 +1,58 @@
 import unittest
+import os
+import tempfile
 
 from src.Show import Show
-from src.Configuration import Configuration, CONFIG_FILE, SAMPLE_CONFIG, DOWNLOAD_DIR
-from os import remove
+from src.Configuration import Configuration, DOWNLOAD_DIR, SHOW_LIST
 
 
 class ConfigTestCase(unittest.TestCase):
-    
+
+    # run every test in a temp dir so we never touch a real config file
+    def setUp(self):
+        self._old_cwd = os.getcwd()
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        os.chdir(self._tmp_dir.name)
+
+    def tearDown(self):
+        os.chdir(self._old_cwd)
+        self._tmp_dir.cleanup()
+
     def test_config_file_opearations(self):
-        config = Configuration.create_config(SAMPLE_CONFIG[DOWNLOAD_DIR])
-        
+        sample = Configuration.get_sample_config()
+        config = Configuration.create_config(sample[DOWNLOAD_DIR])
+
         res_config = Configuration.try_get_config_json()
-        
+
         self.assertEqual(config.config_json, res_config)
-        remove(CONFIG_FILE)
-    
+
     def test_add_show(self):
-        config = Configuration(SAMPLE_CONFIG)
-        
-        show = Show('show', 'parser', 'filter', 'link')
-        
+        config = Configuration(Configuration.get_sample_config())
+
+        show = Show('show', 'parser', 'filter', 'link', None)
+
         self.assertNotIn(show, config.show_list)
         config.add_show(show)
-        self.assertIn(show, config.show_list)    
-    
+        self.assertIn(show, config.show_list)
+
+    def test_remove_show(self):
+        config = Configuration(Configuration.get_sample_config())
+
+        show = Show('show', 'parser', 'filter', 'link', None)
+
+        config.add_show(show)
+        self.assertIn(show, config.show_list)
+        config.remove_show(show)
+        self.assertNotIn(show, config.show_list)
+        self.assertEqual(config.config_json[SHOW_LIST], [])
+
     def test_check_config_json(self):
         invalid = {
             'not enough': 'data'
         }
-        
+
         self.assertFalse(Configuration.check_config_json(invalid))
-        self.assertTrue(Configuration.check_config_json(SAMPLE_CONFIG))
+        self.assertTrue(Configuration.check_config_json(Configuration.get_sample_config()))
 
 if __name__ == '__main__':
     unittest.main()
-    

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -7,6 +7,7 @@ json_show_obj = {
             "parser": 'parser',
             "filter": 'show filter',
             "link": 'https://show.com',
+            "last_episode": None,
         }
 
 json_show_obj_invalid = {
@@ -16,17 +17,16 @@ json_show_obj_invalid = {
         }
 
 
-show_obj = Show('title', 'parser', 'show filter', 'https://show.com')
+show_obj = Show('title', 'parser', 'show filter', 'https://show.com', None)
 
 class ShowTestCase(unittest.TestCase):
-    
+
     def test_to_json(self):
         self.assertEqual(show_obj.to_json(), json_show_obj)
-    
+
     def test_from_json(self):
         self.assertEqual(Show.from_json(json_show_obj), show_obj)
         self.assertEqual(Show.from_json(json_show_obj_invalid), None)
 
 if __name__ == '__main__':
     unittest.main()
-    


### PR DESCRIPTION
Fixes a batch of bugs found in a code review:

**Crashes / hangs**
- Invalid show entries in the config crashed the app later with `AttributeError` - the `None` check in `Configuration.__init__` was on the raw JSON dict, not the parse result
- `NonMagicParserBase.get_show_filter` validated the episode number against the unfiltered list but indexed the filtered one -> `IndexError` (and the "None of these" entry could be unselectable)
- One failing tracker killed the whole "update all": checker threads had no exception handling, leaving `None` results that crashed `to_download.extend`
- No HTTP timeout - a stalled tracker connection hung the app forever
- `TheRARBGParser.get_magnet` can return `None`, which reached `os.startfile(None)` mid-download-batch

**Wrong behavior**
- EZTV `stop_after` compared the episode title against the second *character* of the raw HTML row (pattern has no capture groups) - never fired; rows without magnet/epinfo links raised `IndexError`
- Downloads were silently skipped on macOS (`sys.platform` checked only `win32`/`linux`); added a macOS sample config using `open`
- `get_sample_config` returned the shared module-level dict, which then got mutated
- Selecting "None of these" stored the literal string as `last_episode` instead of `None`
- The 2->3 config migration overwrote the V2 backup file; unknown config versions crashed with `KeyError`
- `remove_show` required exact dict equality and threw `ValueError` on configs with extra keys

**Tests**
- Both test files failed at import (stale `SAMPLE_CONFIG` import, old `Show` constructor arity) - updated to the current API
- Config tests now run in a temp directory: previously they wrote and then **deleted** `sys_torrent.cfg` in the CWD, destroying a real config if run from the repo root

All tests pass; a real v3 config with 10 shows loads cleanly through the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
